### PR TITLE
null-safety-dart3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.1] - 2025-07-26
+- Migrate to null safety (Dart >= 2.12.0).
+- Update dependencies to support Flutter 3.x / Dart 3.x.
+
 ## 1.0.1
 
 - Updated google_maps_flutter version and play-services-location to latest.

--- a/lib/google_map_polyutil.dart
+++ b/lib/google_map_polyutil.dart
@@ -1,6 +1,5 @@
 import 'package:google_map_polyutil/gmp.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
-import 'package:meta/meta.dart';
 
 /// A helper class regarding Google map native android utility class "PolyUtil".
 /// For brief documentation from native class goto
@@ -16,16 +15,12 @@ class GoogleMapPolyUtil {
   /// geodesic is true, and of rhumb (loxodromic) segments
   /// otherwise.
   ///
-  static Future<bool> containsLocation(
-          {@required LatLng point,
-          @required List<LatLng> polygon,
-          bool geodesic = true}) =>
+  static Future<bool> containsLocation({required LatLng point, required List<LatLng> polygon, bool geodesic = true}) =>
       GMP.containsLocation(point, polygon, geodesic);
 
   /// Decodes an encoded path string into a sequence of LatLngs.
   ///
-  static Future<List<LatLng>> decode({@required String encodedPath}) =>
-      GMP.decode(encodedPath);
+  static Future<List<LatLng>> decode({required String encodedPath}) => GMP.decode(encodedPath);
 
   /// Computes the distance on the sphere between the point p
   /// and the line segment start to end.
@@ -34,24 +29,18 @@ class GoogleMapPolyUtil {
   /// * _[start]_ - the beginning of line segment.
   /// * _[end]_ - the end of the line segment.
   ///
-  static Future<double> distanceToLine(
-          {@required LatLng point,
-          @required LatLng start,
-          @required LatLng end}) =>
-      GMP.distanceToLine(point, start, end);
+  static Future<double> distanceToLine({required LatLng point, required LatLng start, required LatLng end}) => GMP.distanceToLine(point, start, end);
 
   /// Encodes a sequence of LatLngs into an encoded path string.
   ///
-  static Future<String> encode({@required List<LatLng> path}) =>
-      GMP.encode(path);
+  static Future<String> encode({required List<LatLng> path}) => GMP.encode(path);
 
   /// Returns true if the provided list of points is a closed polygon
   /// (i.e., the first and last points are the same), and false if it is not
   /// ### Parameters:
   /// * _[poly]_ -  polyline or polygon.
   ///
-  static Future<bool> isClosedPolygon({@required List<LatLng> poly}) =>
-      GMP.isClosedPolygon(poly);
+  static Future<bool> isClosedPolygon({required List<LatLng> poly}) => GMP.isClosedPolygon(poly);
 
   /// Computes whether the given point lies on or near the edge of a polygon,
   /// within a specified tolerance in meters. The polygon edge is composed of
@@ -59,11 +48,12 @@ class GoogleMapPolyUtil {
   /// otherwise. The polygon edge is implicitly closed -- the closing segment
   /// between the first point and the last point is included.
   ///
-  static Future<bool> isLocationOnEdge(
-          {@required LatLng point,
-          List<LatLng> polygon,
-          bool geodesic = true,
-          double tolerance = 100}) =>
+  static Future<bool> isLocationOnEdge({
+    required LatLng point,
+    required List<LatLng> polygon,
+    bool geodesic = true,
+    double tolerance = 100,
+  }) =>
       GMP.isLocationOnEdge(point, polygon, geodesic, tolerance);
 
   /// Computes whether the given point lies on or near a polyline, within a
@@ -72,11 +62,12 @@ class GoogleMapPolyUtil {
   /// is not closed -- the closing segment between the first point and the last
   /// point is not included.
   ///
-  static Future<bool> isLocationOnPath(
-          {@required LatLng point,
-          List<LatLng> polygon,
-          bool geodesic = true,
-          double tolerance = 200}) =>
+  static Future<bool> isLocationOnPath({
+    required LatLng point,
+    required List<LatLng> polygon,
+    bool geodesic = true,
+    double tolerance = 200,
+  }) =>
       GMP.isLocationOnPath(point, polygon, geodesic, tolerance);
 
   /// Simplifies the given poly (polyline or polygon) using the Douglas-Peucker
@@ -93,7 +84,5 @@ class GoogleMapPolyUtil {
   /// * _[tolerance]_ - in meters. Increasing the tolerance will result in fewer
   /// points in the simplified poly.
   ///
-  static Future<List<LatLng>> simplify(
-          {@required List<LatLng> poly, @required double tolerance}) =>
-      GMP.simplify(poly, tolerance);
+  static Future<List<LatLng>> simplify({required List<LatLng> poly, required double tolerance}) => GMP.simplify(poly, tolerance);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,51 +5,58 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0-nullsafety.3"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.19.1"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -59,124 +66,233 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      url: "https://pub.dartlang.org"
+      sha256: f948e346c12f8d5480d2825e03de228d0eb8c3a737e4cdaa122267b89c022b5e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.11"
+    version: "2.0.28"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  google_maps:
+    dependency: transitive
+    description:
+      name: google_maps
+      sha256: "4d6e199c561ca06792c964fa24b2bac7197bf4b401c2e1d23e345e5f9939f531"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.1"
   google_maps_flutter:
     dependency: "direct main"
     description:
       name: google_maps_flutter
-      url: "https://pub.dartlang.org"
+      sha256: e1805e5a5885bd14a1c407c59229f478af169bf4d04388586b19f53145a5db3a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.10"
+    version: "2.12.3"
+  google_maps_flutter_android:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_android
+      sha256: "67745f7850655faa8a596606b627fece63f3011078eaa0c151a4774568c23ac4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.17.0"
+  google_maps_flutter_ios:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_ios
+      sha256: d03678415da9de8ce7208c674b264fc75946f326e696b4b7f84c80920fc58df6
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.4"
   google_maps_flutter_platform_interface:
     dependency: transitive
     description:
       name: google_maps_flutter_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: f8293f072ed8b068b092920a72da6693aa8b3d62dc6b5c5f0bc44c969a8a776c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "2.12.1"
+  google_maps_flutter_web:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_web
+      sha256: ce2cac714e5462bf761ff2fdfc3564c7e5d7ed0578268dccb0a54dbdb1e6214e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.12+2"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.6"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.9"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.9"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.17"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.1"
   meta:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.9.1"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "2.1.8"
+  sanitize_html:
+    dependency: transitive
+    description:
+      name: sanitize_html
+      sha256: "12669c4a913688a26555323fb9cec373d8f9fbe091f2d01c40c723b33caa8989"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.19-nullsafety.2"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.22.0 <2.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,14 +4,13 @@ version: 1.0.1
 homepage: https://github.com/ayyshim/google_map_polyutil
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.12.0 <2.0.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_flutter: ^1.0.10
-  meta: ^1.1.8
+  google_maps_flutter: ^2.12.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
✨ Migration to Dart 3 and Null Safety
This PR updates the google_map_polyutil plugin to support modern Flutter and Dart versions by introducing null safety and SDK compatibility improvements.

✅ Key changes:
Fully migrated the codebase to null safety

Updated SDK constraints to "sdk: ">=3.0.0 <4.0.0" for Dart 3 support

Bumped google_maps_flutter dependency to a null-safe version (^2.12.3)

Fixed method signatures (isLocationOnEdge, isLocationOnPath) to remove nullable list warnings

Cleaned up pubspec.yaml to allow flutter pub publish --dry-run to succeed

📦 Why this PR?
The current version of the package does not support null safety, making it unusable in up-to-date Flutter apps. This PR ensures compatibility with Dart 3 and recent Flutter versions while preserving existing functionality.

🧪 Manual testing:
Verified with a Flutter 3.32.6 / Dart 3.8.1 setup